### PR TITLE
[編譯器] #8 已完成項目顯示模組

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { fetchAgentStatuses, createStatusPoller, type AgentStatus } from './services/api/agentStatus'
+import { fetchCompletedTasks, type CompletedTask } from './services/api/completedTasks'
 
 // 項目類型
 interface Project {
@@ -15,8 +16,14 @@ interface Project {
 function App() {
   const [agents, setAgents] = useState<AgentStatus[]>([])
   const [projects, setProjects] = useState<Project[]>([])
+  const [completedTasks, setCompletedTasks] = useState<CompletedTask[]>([])
   const [loading, setLoading] = useState(true)
+  const [completedLoading, setCompletedLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [sortOrder, setSortOrder] = useState<'desc' | 'asc'>('desc')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [hasMore, setHasMore] = useState(true)
+  const loaderRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     // 初始載入
@@ -90,6 +97,80 @@ function App() {
     setProjects(mockProjects)
   }, [])
 
+  // 載入已完成任務（從 API 獲取）
+  useEffect(() => {
+    const loadCompletedTasks = async () => {
+      setCompletedLoading(true)
+      try {
+        const tasks = await fetchCompletedTasks({
+          sortBy: 'closed_at',
+          sortOrder: sortOrder,
+          perPage: 10,
+          page: 1
+        })
+        setCompletedTasks(tasks)
+        setHasMore(tasks.length >= 10)
+      } catch (err) {
+        console.error('Failed to load completed tasks:', err)
+      } finally {
+        setCompletedLoading(false)
+      }
+    }
+    loadCompletedTasks()
+  }, [sortOrder])
+
+  // 無限滾動載入更多
+  const loadMoreTasks = useCallback(async () => {
+    if (completedLoading || !hasMore) return
+    
+    setCompletedLoading(true)
+    try {
+      const nextPage = currentPage + 1
+      const newTasks = await fetchCompletedTasks({
+        sortBy: 'closed_at',
+        sortOrder: sortOrder,
+        perPage: 10,
+        page: nextPage
+      })
+      
+      if (newTasks.length > 0) {
+        setCompletedTasks(prev => [...prev, ...newTasks])
+        setCurrentPage(nextPage)
+        setHasMore(newTasks.length >= 10)
+      } else {
+        setHasMore(false)
+      }
+    } catch (err) {
+      console.error('Failed to load more tasks:', err)
+    } finally {
+      setCompletedLoading(false)
+    }
+  }, [completedLoading, hasMore, currentPage, sortOrder])
+
+  // 監聽滾動以觸發載入更多
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !completedLoading) {
+          loadMoreTasks()
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [loadMoreTasks, hasMore, completedLoading])
+
+  // 切換排序順序
+  const toggleSortOrder = () => {
+    setSortOrder(prev => prev === 'desc' ? 'asc' : 'desc')
+    setCurrentPage(1)
+  }
+
   const getStatusLabel = (status: AgentStatus['status']) => {
     switch (status) {
       case 'idle': return '閒置'
@@ -127,7 +208,6 @@ function App() {
   }
 
   const inProgressProjects = projects.filter(p => p.status === 'in_progress')
-  const completedProjects = projects.filter(p => p.status === 'completed')
 
   return (
     <div className="dashboard">
@@ -207,27 +287,51 @@ function App() {
 
         {/* Completed Section */}
         <section className="section">
-          <h2 className="section-title">已完成項目</h2>
-          {completedProjects.map(project => (
-            <div key={project.id} className="project-card">
-              <div className="project-header">
-                <div className="project-title">
-                  <span>✅</span>
-                  {project.title}
+          <div className="section-header">
+            <h2 className="section-title">已完成項目</h2>
+            <button 
+              className="sort-btn" 
+              onClick={toggleSortOrder}
+              title={sortOrder === 'desc' ? '最新優先' : '最舊優先'}
+            >
+              {sortOrder === 'desc' ? '📅 最新優先' : '📅 最舊優先'}
+            </button>
+          </div>
+          {completedTasks.length === 0 && !completedLoading ? (
+            <div className="empty-state">暫無已完成項目</div>
+          ) : (
+            <>
+              {completedTasks.map(task => (
+                <div key={task.id} className="project-card">
+                  <div className="project-header">
+                    <div className="project-title">
+                      <span>✅</span>
+                      <a href={task.url} target="_blank" rel="noopener noreferrer">
+                        {task.title}
+                      </a>
+                    </div>
+                    <div className="project-meta">
+                      {task.agentEmoji} {task.agentName}
+                      {task.completedAt && ` · ${formatTimeAgo(task.completedAt)}`}
+                    </div>
+                  </div>
+                  <div className="progress-bar">
+                    <div 
+                      className="progress-fill completed" 
+                      style={{ width: '100%' }}
+                    ></div>
+                  </div>
                 </div>
-                <div className="project-meta">
-                  {project.agentEmoji} {project.agentName}
-                  {project.completedAt && ` · ${formatTimeAgo(project.completedAt)}`}
-                </div>
+              ))}
+              {/* Infinite scroll loader */}
+              <div ref={loaderRef} className="load-more">
+                {completedLoading && <div className="loading-spinner">載入中...</div>}
+                {!hasMore && completedTasks.length > 0 && (
+                  <div className="end-message">已載入全部</div>
+                )}
               </div>
-              <div className="progress-bar">
-                <div 
-                  className="progress-fill completed" 
-                  style={{ width: '100%' }}
-                ></div>
-              </div>
-            </div>
-          ))}
+            </>
+          )}
         </section>
       </main>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,61 @@ body {
   gap: 8px;
 }
 
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.section-header .section-title {
+  margin-bottom: 0;
+}
+
+.sort-btn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  background: var(--bg-light);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.sort-btn:hover {
+  background: var(--primary);
+  color: var(--text-primary);
+  border-color: var(--primary);
+}
+
+.load-more {
+  text-align: center;
+  padding: 16px;
+}
+
+.end-message {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.project-title a {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.project-title a:hover {
+  color: var(--primary);
+  text-decoration: underline;
+}
+
 .section-title::before {
   content: '';
   width: 4px;

--- a/src/services/api/completedTasks.ts
+++ b/src/services/api/completedTasks.ts
@@ -1,0 +1,107 @@
+// Completed Tasks API Service
+// 從 GitHub Issues API 獲取已完成任務的歷史記錄
+
+export interface CompletedTask {
+  id: number
+  title: string
+  agentName: string
+  agentEmoji: string
+  completedAt: Date
+  url: string
+}
+
+export interface FetchCompletedTasksOptions {
+  sortBy?: 'created' | 'updated' | 'comments' | 'closed_at'
+  sortOrder?: 'asc' | 'desc'
+  perPage?: number
+  page?: number
+}
+
+// 從 issue 標籤解析 Agent 名稱
+function parseAgentFromIssue(issue: any): { name: string; emoji: string } {
+  // 檢查標籤中的 Agent 識別
+  const agentLabels = issue.labels
+    ?.map((l: any) => l.name)
+    ?.filter((name: string) => 
+      ['指揮台', '透析器', '調色盤', '編譯器', '鑑賞家', '測試台', '部署艦'].includes(name)
+    )
+
+  const agentMap: Record<string, { name: string; emoji: string }> = {
+    '指揮台': { name: '指揮台', emoji: '📋' },
+    '透析器': { name: '透析器', emoji: '🔍' },
+    '調色盤': { name: '調色盤', emoji: '🎨' },
+    '編譯器': { name: '編譯器', emoji: '⚙️' },
+    '鑑賞家': { name: '鑑賞家', emoji: '🖼️' },
+    '測試台': { name: '測試台', emoji: '🧪' },
+    '部署艦': { name: '部署艦', emoji: '🚀' },
+  }
+
+  if (agentLabels && agentLabels.length > 0) {
+    return agentMap[agentLabels[0]] || { name: '未知', emoji: '❓' }
+  }
+
+  // 從 issue 內容或標題推斷 Agent（如果標題包含 Agent 名稱）
+  for (const [key, value] of Object.entries(agentMap)) {
+    if (issue.title.includes(key)) {
+      return value
+    }
+  }
+
+  return { name: '未知', emoji: '❓' }
+}
+
+// 從 GitHub API 獲取已完成任務
+export async function fetchCompletedTasks(
+  options: FetchCompletedTasksOptions = {}
+): Promise<CompletedTask[]> {
+  const { sortBy = 'closed_at', sortOrder = 'desc', perPage = 20, page = 1 } = options
+
+  try {
+    // 調用 GitHub API 獲取已關閉的 issues
+    const owner = 'ks885522'
+    const repo = 'Openclaw-team-Dashboard'
+    const response = await fetch(
+      `/api/github/repos/${owner}/${repo}/issues?state=closed&sort=${sortBy}&direction=${sortOrder}&per_page=${perPage}&page=${page}`
+    )
+
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`)
+    }
+
+    const issues = await response.json()
+
+    // 過濾掉 Pull Requests，只保留 Issues
+    const tasks = issues
+      .filter((issue: any) => !issue.pull_request)
+      .map((issue: any) => {
+        const { name, emoji } = parseAgentFromIssue(issue)
+        
+        return {
+          id: issue.number,
+          title: issue.title,
+          agentName: name,
+          agentEmoji: emoji,
+          completedAt: new Date(issue.closed_at),
+          url: issue.html_url,
+        }
+      })
+
+    return tasks
+  } catch (error) {
+    console.error('Failed to fetch completed tasks:', error)
+    return []
+  }
+}
+
+// 滾動載入更多已完成任務
+export async function fetchMoreCompletedTasks(
+  page: number,
+  perPage: number = 20
+): Promise<CompletedTask[]> {
+  return fetchCompletedTasks({ page, perPage })
+}
+
+export default {
+  fetchCompletedTasks,
+  fetchMoreCompletedTasks,
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000
-  }
+    port: 3000,
+    proxy: {
+      '/api/github': {
+        target: 'https://api.github.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/github/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 變更內容

- 新增 `completedTasks.ts` API service
- 從 GitHub Issues API 獲取已完成任務
- 支援時間排序（最新/最舊切換）
- 支援無限滾動載入

## 測試方式

1. 啟動開發伺服器：`npm run dev`
2. 滾動至「已完成項目」區塊
3. 點擊排序按鈕切換排序方式
4. 滾動頁面測試無限載入

## 驗收標準

- [x] 可顯示每個 Agent 歷史完成的 Task 清單
- [x] 可按時間排序
- [x] 支援分頁或滾動載入