### PR TITLE
[編譯器] #30 Add Dark Mode Theme Support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,10 @@ function App() {
   const [sortOrder, setSortOrder] = useState<'desc' | 'asc'>('desc')
   const [currentPage, setCurrentPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
+  const [theme, setTheme] = useState<'dark' | 'light'>(() => {
+    const saved = localStorage.getItem('dashboard-theme')
+    return (saved as 'dark' | 'light') || 'dark'
+  })
   const loaderRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -46,6 +50,16 @@ function App() {
       stopPolling()
     }
   }, [])
+
+  // 主題切換
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('dashboard-theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'dark' ? 'light' : 'dark')
+  }
 
   // 模擬項目數據（實際應該從 API 獲取）
   useEffect(() => {
@@ -218,6 +232,13 @@ function App() {
           <h1 className="header-title">OpenClaw Team Dashboard</h1>
         </div>
         <div className="header-actions">
+          <button 
+            className="icon-btn" 
+            title={theme === 'dark' ? '切換到淺色主題' : '切換到深色主題'}
+            onClick={toggleTheme}
+          >
+            {theme === 'dark' ? '☀️' : '🌙'}
+          </button>
           <button 
             className="icon-btn" 
             title="重新整理"

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,21 @@
   background-color: var(--bg-dark);
 }
 
+/* Light Theme */
+[data-theme="light"] {
+  --bg-dark: #F5F7FA;
+  --bg-card: #FFFFFF;
+  --bg-light: #E8ECF1;
+  --border: #D1D9E6;
+  
+  --text-primary: #1A1D21;
+  --text-secondary: #5C6577;
+  --text-muted: #8B95A5;
+  
+  color-scheme: light;
+  color: rgba(26, 29, 33, 0.87);
+}
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## 變更內容

- Add CSS variables for light theme in index.css
- Add theme toggle button in dashboard header
- Theme preference persists in localStorage

## 測試方式
1. Run npm run dev
2. Click sun/moon icon to toggle themes
3. Refresh page - theme should persist

Closes #30