### PR TITLE
[編譯器] #31 Toast Notification System

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { fetchAgentStatuses, createStatusPoller, type AgentStatus } from './services/api/agentStatus'
 import { fetchCompletedTasks, type CompletedTask } from './services/api/completedTasks'
+import { useToast, ToastContainer, showToast } from './hooks/useToast'
 
 // 項目類型
 interface Project {
@@ -27,6 +28,7 @@ function App() {
     const saved = localStorage.getItem('dashboard-theme')
     return (saved as 'dark' | 'light') || 'dark'
   })
+  const { toasts, removeToast } = useToast()
   const loaderRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -39,11 +41,30 @@ function App() {
       .catch(err => {
         setError(err.message)
         setLoading(false)
+        showToast('error', '載入 Agent 狀態失敗')
       })
 
     // 啟動輪詢更新（每 30 秒刷新一次）
     const stopPolling = createStatusPoller((updatedAgents) => {
-      setAgents(updatedAgents)
+      // 檢測狀態變化並顯示通知
+      setAgents(prevAgents => {
+        const prevMap = new Map(prevAgents.map(a => [a.id, a.status]))
+        updatedAgents.forEach(agent => {
+          const prevStatus = prevMap.get(agent.id)
+          if (prevStatus && prevStatus !== agent.status) {
+            const statusMessages: Record<string, Record<string, string>> = {
+              idle: { busy: '已閒置', offline: '已離線' },
+              busy: { idle: '現在閒置', offline: '已離線' },
+              offline: { idle: '上線了', busy: '上線了' }
+            }
+            const msg = statusMessages[prevStatus]?.[agent.status]
+            if (msg) {
+              showToast('info', `${agent.name} ${msg}`)
+            }
+          }
+        })
+        return updatedAgents
+      })
     }, 30000)
 
     return () => {
@@ -225,6 +246,7 @@ function App() {
 
   return (
     <div className="dashboard">
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
       {/* Header */}
       <header className="header">
         <div className="header-left">

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react'
+
+export type ToastType = 'success' | 'error' | 'info'
+
+export interface Toast {
+  id: string
+  type: ToastType
+  message: string
+}
+
+let toastId = 0
+let globalAddToast: ((toast: Omit<Toast, 'id'>) => void) | null = null
+
+export const showToast = (type: ToastType, message: string) => {
+  if (globalAddToast) {
+    globalAddToast({ type, message })
+  }
+}
+
+// Toast 通知 Hook
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = `toast-${++toastId}`
+    const newToast = { ...toast, id }
+    
+    setToasts(prev => [...prev, newToast])
+    
+    // 3秒後自動移除
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id))
+    }, 3000)
+  }, [])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  // 設置全局函數以便從任何地方調用
+  globalAddToast = addToast
+
+  return { toasts, addToast, removeToast }
+}
+
+// Toast 組件
+interface ToastContainerProps {
+  toasts: Toast[]
+  onRemove: (id: string) => void
+}
+
+export function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
+  const getIcon = (type: ToastType) => {
+    switch (type) {
+      case 'success': return '✅'
+      case 'error': return '❌'
+      case 'info': return 'ℹ️'
+    }
+  }
+
+  return (
+    <div className="toast-container">
+      {toasts.map(toast => (
+        <div 
+          key={toast.id} 
+          className={`toast toast-${toast.type}`}
+          onClick={() => onRemove(toast.id)}
+        >
+          <span className="toast-icon">{getIcon(toast.type)}</span>
+          <span className="toast-message">{toast.message}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -389,3 +389,76 @@ body {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* Toast Notification System */
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  animation: slideIn 0.3s ease-out;
+  max-width: 320px;
+}
+
+.toast:hover {
+  opacity: 0.9;
+}
+
+.toast-success {
+  border-left: 4px solid var(--status-idle);
+}
+
+.toast-error {
+  border-left: 4px solid var(--status-offline);
+}
+
+.toast-info {
+  border-left: 4px solid var(--status-progress);
+}
+
+.toast-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.toast-message {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## 變更內容
- 新增 useToast hook 和 showToast API
- 新增 ToastContainer 組件顯示通知
- 支援 success、error、info 三種類型
- 3秒後自動消失（帶動畫）
- 監聽 Agent 狀態變化並顯示通知

## 測試方式
1. 啟動開發伺服器：npm run dev
2. 觀察 Agent 卡片狀態變化（每30秒輪詢）
3. 當 Agent 狀態改變時，應該顯示 Toast 通知

## 截圖
Toast 通知會出現在右上角，點擊可關閉