### PR TITLE
[編譯器] #72 Agent 數據日誌即時寫入

### DIFF
--- a/server/api-server.js
+++ b/server/api-server.js
@@ -10,6 +10,34 @@ const REPO_OWNER = 'ks885522';
 const REPO_NAME = 'Openclaw-team-Dashboard';
 
 /**
+ * Ensure log directory exists
+ */
+function ensureLogDir() {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Write a log entry to the JSON log file (supports real-time)
+ */
+function writeAgentLog(logEntry) {
+  ensureLogDir();
+  
+  const logLine = JSON.stringify(logEntry) + '\n';
+  
+  fs.appendFile(AGENT_LOG_FILE, logLine, (err) => {
+    if (err) {
+      console.error('[AgentLogger] Failed to write to log file:', err);
+      return false;
+    }
+    return true;
+  });
+  
+  return true;
+}
+
+/**
  * Read agent activity logs from file
  */
 function readAgentLogs(agentId = null) {
@@ -237,7 +265,7 @@ function calculateLogMetrics() {
 
 const server = http.createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 
   if (req.method === 'OPTIONS') {
@@ -247,7 +275,47 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.url.startsWith('/api/agent-logs')) {
-    // Get query param for agent_id filter
+    // POST: Create a new log entry (real-time logging)
+    if (req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        try {
+          const logEntry = JSON.parse(body);
+          
+          // Validate required fields
+          if (!logEntry.agent_id || !logEntry.action || !logEntry.outcome) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Missing required fields: agent_id, action, outcome' }));
+            return;
+          }
+          
+          // Add timestamp if not provided
+          if (!logEntry.timestamp) {
+            logEntry.timestamp = new Date().toISOString();
+          }
+          
+          // Write to file
+          const success = writeAgentLog(logEntry);
+          
+          if (success) {
+            res.writeHead(201, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: true, log: logEntry }));
+          } else {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Failed to write log' }));
+          }
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid JSON: ' + err.message }));
+        }
+      });
+      return;
+    }
+    
+    // GET: Read logs
     const url = new URL(req.url, `http://localhost:${PORT}`);
     const agentId = url.searchParams.get('agent_id');
     

--- a/src/services/logger/agent-logger.ts
+++ b/src/services/logger/agent-logger.ts
@@ -3,6 +3,7 @@
  * 
  * Centralized logging utility for all Agents to record activity logs.
  * Logs are written to both console and a JSON file for persistence.
+ * Supports real-time logging via API when available.
  * 
  * Usage:
  *   import { agentLogger } from './services/logger/agent-logger';
@@ -12,6 +13,9 @@
  *     task_id: '123',
  *     duration_ms: 5000
  *   });
+ *   
+ *   // Enable real-time logging to API server
+ *   agentLogger.setRealtimeMode(true, 'http://localhost:3001');
  */
 
 import * as fs from 'fs';
@@ -27,7 +31,12 @@ interface LogOptions {
   metadata?: Record<string, unknown>;
   duration_ms?: number;
   error_message?: string;
+  realtime?: boolean; // Override realtime setting for this log
 }
+
+// Configuration for real-time mode
+let realtimeEnabled = false;
+let apiServerUrl = 'http://localhost:3001';
 
 /**
  * Ensure the log directory exists
@@ -54,6 +63,28 @@ function writeToFile(log: AgentActivityLog): void {
 }
 
 /**
+ * Send log to API server for real-time logging
+ */
+async function sendToApi(log: AgentActivityLog): Promise<boolean> {
+  if (!realtimeEnabled) return false;
+  
+  try {
+    const response = await fetch(`${apiServerUrl}/api/agent-logs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(log)
+    });
+    
+    return response.ok;
+  } catch (err) {
+    // Silently fail - real-time logging is best-effort
+    return false;
+  }
+}
+
+/**
  * Format log entry for console output
  */
 function formatForConsole(log: AgentActivityLog): string {
@@ -68,6 +99,24 @@ function formatForConsole(log: AgentActivityLog): string {
  * Agent Logger - Centralized logging for all Agents
  */
 export const agentLogger = {
+  /**
+   * Enable or disable real-time logging to API server
+   */
+  setRealtimeMode(enabled: boolean, serverUrl?: string): void {
+    realtimeEnabled = enabled;
+    if (serverUrl) {
+      apiServerUrl = serverUrl;
+    }
+    console.log(`[AgentLogger] Real-time mode: ${enabled ? 'enabled' : 'disabled'}`);
+  },
+
+  /**
+   * Check if real-time mode is enabled
+   */
+  isRealtimeEnabled(): boolean {
+    return realtimeEnabled;
+  },
+
   /**
    * Log an Agent activity
    */
@@ -88,8 +137,14 @@ export const agentLogger = {
     // Write to console
     console.log(`[Agent:${agentId}]`, formatForConsole(logEntry));
     
-    // Write to file
+    // Write to file (always)
     writeToFile(logEntry);
+    
+    // Send to API if realtime is enabled (and not explicitly disabled for this log)
+    const shouldRealtime = options?.realtime !== false && realtimeEnabled;
+    if (shouldRealtime) {
+      sendToApi(logEntry);
+    }
     
     return logEntry;
   },


### PR DESCRIPTION
## 變更內容

### Issue #72 - Agent 數據日誌格式與收集

實作內容：
1. **新增 POST /api/agent-logs 端點** - 支援即時日誌寫入
2. **更新 agent-logger.ts** - 新增即時日誌模式 (realtime mode)

### 功能說明
- **即時日誌 API**：POST /api/agent-logs 接收 JSON 格式日誌
- **Logger 增強**：agentLogger.setRealtimeMode(true) 啟用即時模式

### 測試
curl -X POST http://localhost:3001/api/agent-logs -H "Content-Type: application/json" -d '{"agent_id":"engineering","action":"task_completed","outcome":"success","task_id":"72"}'

### 標籤
backend
