### PR TITLE
[編譯器] #97 日誌串流架構 (SSE)

### DIFF
--- a/logs/agent-scores.json
+++ b/logs/agent-scores.json
@@ -1,0 +1,17 @@
+{
+  "devops": {
+    "total": 7,
+    "history": [
+      {
+        "points": 10,
+        "reason": "PR #38 merged (synced)",
+        "timestamp": "2026-03-15T03:03:45.144Z"
+      },
+      {
+        "points": -3,
+        "reason": "PR #38 closed (synced)",
+        "timestamp": "2026-03-15T03:03:45.145Z"
+      }
+    ]
+  }
+}

--- a/server/api-server.js
+++ b/server/api-server.js
@@ -368,6 +368,74 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // SSE endpoint for real-time log streaming
+  if (req.url.startsWith('/api/logs/stream')) {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    const agentId = url.searchParams.get('agent_id');
+    
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Access-Control-Allow-Origin': '*'
+    });
+    
+    // Send initial connection message
+    res.write(`data: ${JSON.stringify({ type: 'connected', message: 'SSE connection established' })}\n\n`);
+    
+    // Track last log position for new entries
+    let lastSize = 0;
+    try {
+      if (fs.existsSync(AGENT_LOG_FILE)) {
+        lastSize = fs.statSync(AGENT_LOG_FILE).size;
+      }
+    } catch (e) {}
+    
+    // Poll for new logs every 1 second
+    const intervalId = setInterval(() => {
+      try {
+        if (fs.existsSync(AGENT_LOG_FILE)) {
+          const currentSize = fs.statSync(AGENT_LOG_FILE).size;
+          
+          if (currentSize > lastSize) {
+            // Read new content
+            const stream = fs.createReadStream(AGENT_LOG_FILE, { start: lastSize });
+            let newContent = '';
+            
+            stream.on('data', (chunk) => {
+              newContent += chunk.toString();
+            });
+            
+            stream.on('end', () => {
+              const newLines = newContent.split('\n').filter(line => line.trim());
+              newLines.forEach(line => {
+                try {
+                  const log = JSON.parse(line);
+                  // Filter by agent_id if specified
+                  if (!agentId || log.agent_id === agentId) {
+                    res.write(`data: ${JSON.stringify({ type: 'log', ...log })}\n\n`);
+                  }
+                } catch (e) {}
+              });
+            });
+            
+            lastSize = currentSize;
+          }
+        }
+      } catch (e) {
+        console.error('[SSE] Error reading log file:', e.message);
+      }
+    }, 1000);
+    
+    // Clean up on close
+    req.on('close', () => {
+      clearInterval(intervalId);
+      res.end();
+    });
+    
+    return;
+  }
+
   if (req.url.startsWith('/api/agent-logs')) {
     // POST: Create a new log entry (real-time logging)
     if (req.method === 'POST') {


### PR DESCRIPTION
## 變更內容
- 新增  SSE 端點
- 支援即時日誌推送，每秒檢查日誌檔案變更
- 支援 agent_id 參數過濾特定 Agent 的日誌

## 測試方式
```bash
# 測試 SSE 端點
curl -N http://localhost:3001/api/logs/stream

# 測試特定 Agent 過濾
curl -N "http://localhost:3001/api/logs/stream?agent_id=engineering"
```

## 驗收標準 ✅
- [x] 建立 SSE 連線
- [x] 日誌低延遲即時刷新 (每秒輪詢)

## 截圖
SSE 連線測試輸出：
```
data: {"type":"connected","message":"SSE connection established"}
```