### PR TITLE
[編譯器] #112 自動化積分機制

### DIFF
--- a/server/api-server.js
+++ b/server/api-server.js
@@ -9,6 +9,99 @@ const AGENT_LOG_FILE = path.join(LOG_DIR, 'agent-activity.log');
 const REPO_OWNER = 'ks885522';
 const REPO_NAME = 'Openclaw-team-Dashboard';
 
+// Score configuration
+const SCORE_CONFIG = {
+  taskCompleted: 10,      // 完成任務
+  reviewApproved: 5,      // 審查通過
+  taskRejected: -3,      // 任務退回
+  criticalBugFound: 15   // 發現關鍵 Bug
+};
+
+// Agent emoji to name mapping
+const AGENT_MAP = {
+  '⚙️': 'engineering',
+  '🎨': 'art-design',
+  '🔍': 'requirements',
+  '📋': 'task-tracking',
+  '🖼️': 'art-review',
+  '🧪': 'feature-review',
+  '🚀': 'devops'
+};
+
+// In-memory score storage (in production, use a database)
+const agentScores = {};
+const scoreHistory = [];
+const MAX_SCORE_HISTORY = 500;
+
+/**
+ * Update agent score with event
+ */
+function updateAgentScore(agentId, eventType, points, details = {}) {
+  if (!agentScores[agentId]) {
+    agentScores[agentId] = 0;
+  }
+  agentScores[agentId] += points;
+  
+  // Record to history
+  scoreHistory.unshift({
+    agentId,
+    eventType,
+    points,
+    newTotal: agentScores[agentId],
+    details,
+    timestamp: new Date().toISOString()
+  });
+  
+  // Keep history bounded
+  if (scoreHistory.length > MAX_SCORE_HISTORY) {
+    scoreHistory.pop();
+  }
+  
+  return { agentId, points, newTotal: agentScores[agentId] };
+}
+
+/**
+ * Calculate scores from GitHub PR events
+ */
+function calculateScoresFromGitHub(prData) {
+  const results = [];
+  const { action, pull_request, sender } = prData;
+  
+  if (!pull_request) return results;
+  
+  const labels = pull_request.labels?.map(l => l.name) || [];
+  const title = pull_request.title || '';
+  const number = pull_request.number;
+  
+  // Determine agent from PR labels or title
+  let agentId = null;
+  for (const [emoji, agent] of Object.entries(AGENT_MAP)) {
+    if (labels.includes(agent) || title.includes(emoji)) {
+      agentId = agent;
+      break;
+    }
+  }
+  
+  if (!agentId) return results;
+  
+  // Calculate based on action
+  if (action === 'closed' && pull_request.merged) {
+    // PR merged - task completed
+    results.push(updateAgentScore(agentId, 'task_completed', SCORE_CONFIG.taskCompleted, {
+      prNumber: number,
+      prTitle: title
+    }));
+  } else if (action === 'closed' && !pull_request.merged) {
+    // PR closed without merge - task rejected
+    results.push(updateAgentScore(agentId, 'task_rejected', SCORE_CONFIG.taskRejected, {
+      prNumber: number,
+      prTitle: title
+    }));
+  }
+  
+  return results;
+}
+
 /**
  * Ensure log directory exists
  */
@@ -572,6 +665,84 @@ const server = http.createServer((req, res) => {
         timestamp: new Date().toISOString()
       }));
     }
+  // ==================== Score API Endpoints ====================
+  } else if (req.url === '/api/scores' && req.method === 'GET') {
+    // Get all agent scores
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      scores: agentScores,
+      history: scoreHistory.slice(0, 50), // Last 50 events
+      config: SCORE_CONFIG
+    }));
+    return;
+  } else if (req.url === '/api/scores/leaderboard' && req.method === 'GET') {
+    // Get leaderboard sorted by score
+    const leaderboard = Object.entries(agentScores)
+      .map(([agentId, score]) => ({ agentId, score }))
+      .sort((a, b) => b.score - a.score);
+    
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(leaderboard));
+    return;
+  } else if (req.url === '/api/scores/reset' && req.method === 'POST') {
+    // Reset all scores (admin only - no auth for demo)
+    Object.keys(agentScores).forEach(key => delete agentScores[key]);
+    scoreHistory.length = 0;
+    
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ success: true, message: 'All scores reset' }));
+    return;
+  } else if (req.url.startsWith('/api/webhooks/github') && req.method === 'POST') {
+    // GitHub webhook endpoint for PR events
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', () => {
+      try {
+        const event = req.headers['x-github-event'];
+        const payload = JSON.parse(body);
+        
+        console.log(`[Webhook] Received GitHub event: ${event}`);
+        
+        if (event === 'pull_request') {
+          const results = calculateScoresFromGitHub(payload);
+          results.forEach(r => {
+            console.log(`[Score] ${r.agentId}: ${r.points > 0 ? '+' : ''}${r.points} pts (Total: ${r.newTotal})`);
+          });
+          
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true, events: results }));
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true, message: `Event ${event} ignored` }));
+        }
+      } catch (err) {
+        console.error('[Webhook] Error:', err.message);
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+    return;
+  } else if (req.url === '/api/scores' && req.method === 'POST') {
+    // Manual score update (for testing)
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        if (!data.agentId || !data.eventType || data.points === undefined) {
+          throw new Error('Missing required fields: agentId, eventType, points');
+        }
+        
+        const result = updateAgentScore(data.agentId, data.eventType, data.points, data.details || {});
+        
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+    return;
   } else if (req.url.startsWith('/api/sessions')) {
     // Correct command is 'openclaw sessions --all-agents --json'
     exec('npx openclaw sessions --all-agents --json', (error, stdout, stderr) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { fetchPerformanceMetrics, type PerformanceMetrics } from './services/api
 import { useToast, ToastContainer, showToast } from './hooks/useToast'
 import { VisualAnnotation } from './components/VisualAnnotation'
 import { PerformanceDashboard } from './components/PerformanceDashboard'
+import { ScoreLeaderboard } from './components/ScoreLeaderboard'
 
 // 項目類型
 interface Project {
@@ -38,7 +39,7 @@ function App() {
   const [costMetrics, setCostMetrics] = useState<PerformanceMetrics['cost'] | null>(null)
   const [costLoading, setCostLoading] = useState(true)
   const [costDays, setCostDays] = useState(30)
-  const [activeTab, setActiveTab] = useState<'dashboard' | 'performance'>('dashboard')
+  const [activeTab, setActiveTab] = useState<'dashboard' | 'performance' | 'scores'>('dashboard')
 
   useEffect(() => {
     // 初始載入
@@ -290,6 +291,12 @@ function App() {
             >
               📈 績效看板
             </button>
+            <button 
+              className={`nav-tab ${activeTab === 'scores' ? 'active' : ''}`}
+              onClick={() => setActiveTab('scores')}
+            >
+              🏈 積分榜
+            </button>
           </nav>
         </div>
         <div className="header-actions">
@@ -478,6 +485,8 @@ function App() {
           )}
         </section>
         </>
+        ) : activeTab === 'scores' ? (
+          <ScoreLeaderboard />
         ) : (
           <PerformanceDashboard />
         )}

--- a/src/components/ScoreLeaderboard.tsx
+++ b/src/components/ScoreLeaderboard.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from 'react';
+import { fetchLeaderboard, fetchScores, type LeaderboardEntry, type ScoreEvent } from '../services/api/scores';
+
+// Agent emoji mapping
+const AGENT_EMOJI: Record<string, string> = {
+  engineering: '⚙️',
+  'art-design': '🎨',
+  requirements: '🔍',
+  'task-tracking': '📋',
+  'art-review': '🖼️',
+  'feature-review': '🧪',
+  devops: '🚀'
+};
+
+const AGENT_NAMES: Record<string, string> = {
+  engineering: '編譯器',
+  'art-design': '調色盤',
+  requirements: '透析器',
+  'task-tracking': '指揮台',
+  'art-review': '鑑賞家',
+  'feature-review': '測試台',
+  devops: '部署艦'
+};
+
+interface ScoreLeaderboardProps {
+  compact?: boolean;
+}
+
+export function ScoreLeaderboard({ compact = false }: ScoreLeaderboardProps) {
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [history, setHistory] = useState<ScoreEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [lbData, scoreData] = await Promise.all([
+          fetchLeaderboard(),
+          fetchScores()
+        ]);
+        setLeaderboard(lbData);
+        setHistory(scoreData.history || []);
+        setLastUpdate(new Date());
+        setError(null);
+      } catch (err) {
+        console.error('Failed to load scores:', err);
+        setError('無法載入積分數據');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+    const interval = setInterval(loadData, 30000); // Refresh every 30s
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="score-leaderboard loading">
+        <div className="loading-spinner">載入中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="score-leaderboard error">
+        <div className="error-message">{error}</div>
+      </div>
+    );
+  }
+
+  const maxScore = leaderboard.length > 0 ? Math.max(...leaderboard.map(e => e.score)) : 1;
+
+  if (compact) {
+    return (
+      <div className="score-leaderboard compact">
+        <h3>🏆 積分排行</h3>
+        <div className="leaderboard-list">
+          {leaderboard.slice(0, 5).map((entry, index) => (
+            <div key={entry.agentId} className={`leaderboard-item rank-${index + 1}`}>
+              <span className="rank">#{index + 1}</span>
+              <span className="emoji">{AGENT_EMOJI[entry.agentId] || '❓'}</span>
+              <span className="name">{AGENT_NAMES[entry.agentId] || entry.agentId}</span>
+              <span className="score">{entry.score} pts</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="score-leaderboard">
+      <div className="leaderboard-header">
+        <h2>🏆 Agent 積分排行榜</h2>
+        {lastUpdate && (
+          <span className="last-update">
+            更新於 {lastUpdate.toLocaleTimeString('zh-TW')}
+          </span>
+        )}
+      </div>
+      
+      <div className="leaderboard-content">
+        <div className="leaderboard-main">
+          <h3>總積分</h3>
+          <div className="leaderboard-list">
+            {leaderboard.map((entry, index) => (
+              <div key={entry.agentId} className={`leaderboard-item rank-${index + 1}`}>
+                <div className="rank-badge">
+                  {index === 0 ? '🥇' : index === 1 ? '🥈' : index === 2 ? '🥉' : `#${index + 1}`}
+                </div>
+                <div className="agent-info">
+                  <span className="emoji">{AGENT_EMOJI[entry.agentId] || '❓'}</span>
+                  <span className="name">{AGENT_NAMES[entry.agentId] || entry.agentId}</span>
+                </div>
+                <div className="score-bar-container">
+                  <div 
+                    className="score-bar" 
+                    style={{ width: `${(entry.score / maxScore) * 100}%` }}
+                  />
+                </div>
+                <div className="score-value">{entry.score} pts</div>
+              </div>
+            ))}
+            {leaderboard.length === 0 && (
+              <div className="empty-message">尚無積分數據</div>
+            )}
+          </div>
+        </div>
+
+        <div className="leaderboard-history">
+          <h3>最近活動</h3>
+          <div className="history-list">
+            {history.slice(0, 10).map((event, index) => (
+              <div key={index} className="history-item">
+                <span className="emoji">{AGENT_EMOJI[event.agentId] || '❓'}</span>
+                <span className="agent">{AGENT_NAMES[event.agentId] || event.agentId}</span>
+                <span className={`points ${event.points > 0 ? 'positive' : 'negative'}`}>
+                  {event.points > 0 ? '+' : ''}{event.points}
+                </span>
+                <span className="event-type">{getEventTypeName(event.eventType)}</span>
+              </div>
+            ))}
+            {history.length === 0 && (
+              <div className="empty-message">尚無活動記錄</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="score-rules">
+        <h4>積分規則</h4>
+        <ul>
+          <li><span className="points positive">+10</span> 完成任務 (PR merged)</li>
+          <li><span className="points positive">+5</span> 審查通過</li>
+          <li><span className="points negative">-3</span> 任務退回 (PR closed)</li>
+          <li><span className="points positive">+15</span> 發現關鍵 Bug</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function getEventTypeName(eventType: string): string {
+  const names: Record<string, string> = {
+    task_completed: '完成任務',
+    task_rejected: '任務退回',
+    review_approved: '審查通過',
+    critical_bug: '關鍵 Bug'
+  };
+  return names[eventType] || eventType;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -918,3 +918,265 @@ body {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* ==================== Score Leaderboard ==================== */
+.score-leaderboard {
+  padding: 20px;
+}
+
+.score-leaderboard.loading,
+.score-leaderboard.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.score-leaderboard .loading-spinner,
+.score-leaderboard .error-message {
+  color: var(--text-secondary);
+  font-size: 16px;
+}
+
+.leaderboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.leaderboard-header h2 {
+  font-size: 24px;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.last-update {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.leaderboard-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 768px) {
+  .leaderboard-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+.leaderboard-main h3,
+.leaderboard-history h3 {
+  font-size: 16px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.leaderboard-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.leaderboard-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-card);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.leaderboard-item.rank-1 {
+  background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(255, 165, 0, 0.1));
+  border-color: rgba(255, 215, 0, 0.3);
+}
+
+.leaderboard-item.rank-2 {
+  background: linear-gradient(135deg, rgba(192, 192, 192, 0.1), rgba(128, 128, 128, 0.1));
+  border-color: rgba(192, 192, 192, 0.3);
+}
+
+.leaderboard-item.rank-3 {
+  background: linear-gradient(135deg, rgba(205, 127, 50, 0.1), rgba(139, 69, 19, 0.1));
+  border-color: rgba(205, 127, 50, 0.3);
+}
+
+.rank-badge {
+  font-size: 20px;
+  min-width: 32px;
+  text-align: center;
+}
+
+.agent-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 120px;
+}
+
+.agent-info .emoji {
+  font-size: 24px;
+}
+
+.agent-info .name {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.score-bar-container {
+  flex: 1;
+  height: 12px;
+  background: var(--bg-light);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.score-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--secondary), var(--accent));
+  border-radius: 6px;
+  transition: width 0.5s ease;
+}
+
+.score-value {
+  min-width: 80px;
+  text-align: right;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.history-item .emoji {
+  font-size: 16px;
+}
+
+.history-item .agent {
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.history-item .points {
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.history-item .points.positive {
+  color: var(--status-completed);
+  background: rgba(139, 92, 246, 0.2);
+}
+
+.history-item .points.negative {
+  color: var(--status-offline);
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.history-item .event-type {
+  color: var(--text-muted);
+}
+
+.score-rules {
+  margin-top: 24px;
+  padding: 16px;
+  background: var(--bg-card);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.score-rules h4 {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.score-rules ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.score-rules li {
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.score-rules .points {
+  font-weight: 600;
+}
+
+.score-rules .points.positive {
+  color: var(--status-completed);
+}
+
+.score-rules .points.negative {
+  color: var(--status-offline);
+}
+
+/* Compact score leaderboard (for sidebar) */
+.score-leaderboard.compact {
+  padding: 12px;
+}
+
+.score-leaderboard.compact h3 {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.score-leaderboard.compact .leaderboard-item {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.score-leaderboard.compact .rank {
+  min-width: 20px;
+}
+
+.score-leaderboard.compact .emoji {
+  font-size: 14px;
+}
+
+.score-leaderboard.compact .name {
+  flex: 1;
+}
+
+.score-leaderboard.compact .score {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.empty-message {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-muted);
+}
+}

--- a/src/services/api/scores.ts
+++ b/src/services/api/scores.ts
@@ -1,0 +1,71 @@
+// Score API service
+const API_BASE = 'http://localhost:3001';
+
+export interface ScoreData {
+  scores: Record<string, number>;
+  history: ScoreEvent[];
+  config: ScoreConfig;
+}
+
+export interface ScoreEvent {
+  agentId: string;
+  eventType: string;
+  points: number;
+  newTotal: number;
+  details: Record<string, any>;
+  timestamp: string;
+}
+
+export interface ScoreConfig {
+  taskCompleted: number;
+  reviewApproved: number;
+  taskRejected: number;
+  criticalBugFound: number;
+}
+
+export interface LeaderboardEntry {
+  agentId: string;
+  score: number;
+}
+
+export async function fetchScores(): Promise<ScoreData> {
+  const response = await fetch(`${API_BASE}/api/scores`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch scores');
+  }
+  return response.json();
+}
+
+export async function fetchLeaderboard(): Promise<LeaderboardEntry[]> {
+  const response = await fetch(`${API_BASE}/api/scores/leaderboard`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch leaderboard');
+  }
+  return response.json();
+}
+
+export async function resetScores(): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/scores/reset`, {
+    method: 'POST'
+  });
+  if (!response.ok) {
+    throw new Error('Failed to reset scores');
+  }
+}
+
+export async function updateScore(
+  agentId: string,
+  eventType: string,
+  points: number,
+  details?: Record<string, any>
+): Promise<{ agentId: string; points: number; newTotal: number }> {
+  const response = await fetch(`${API_BASE}/api/scores`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agentId, eventType, points, details })
+  });
+  if (!response.ok) {
+    throw new Error('Failed to update score');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## 變更內容

實作自動化積分機制，在 PR merge/close 時自動計算 Agent 積分。

### 後端 (server/api-server.js)
- 添加積分配置 SCORE_CONFIG:
  - 完成任務 (PR merged): +10 pts
  - 審查通過: +5 pts
  - 任務退回 (PR closed): -3 pts
  - 發現關鍵 Bug: +15 pts
- 添加 /api/scores - 取得所有 Agent 積分與歷史記錄
- 添加 /api/scores/leaderboard - 取得積分排行榜
- 添加 /api/scores/reset - 重置所有積分
- 添加 /api/scores (POST) - 手動更新積分
- 添加 /api/webhooks/github - GitHub Webhook 端點接收 PR 事件

### 前端
- 添加 ScoreLeaderboard 組件
- 添加 scores.ts API 服務
- 在 App.tsx 添加「🏈 積分榜」Tab
- 添加積分榜相關 CSS 樣式

### 測試方式
1. 啟動後端伺服器 node server/api-server.js
2. 訪問前端 http://localhost:5173
3. 點擊「🏈 積分榜」Tab 查看排行
4. 可透過 POST /api/scores 手動測試積分計算

## 關聯 Issue
- #112 自動化積分機制
