### PR TITLE
[編譯器] #88 多頻道 Webhook 推播整合 (Slack/Discord/飛書)

### DIFF
--- a/server/api-server.js
+++ b/server/api-server.js
@@ -1218,90 +1218,81 @@ const server = http.createServer((req, res) => {
       return;
     }
     
-    // Webhook Configuration Endpoint
-    if (req.url.startsWith('/api/webhooks/config') && req.method === 'GET') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      // 隱藏敏感資訊
-      const safeConfigs = {};
-      for (const [channel, config] of Object.entries(webhookConfigs)) {
-        safeConfigs[channel] = {
-          enabled: config.enabled,
-          url: config.url ? '***configured***' : '',
-          channel: config.channel
-        };
-      }
-      res.end(JSON.stringify(safeConfigs));
-      return;
-    }
-
-    // Update Webhook Configuration
-    if (req.url.startsWith('/api/webhooks/config') && req.method === 'PUT') {
-      let body = '';
-      req.on('data', chunk => { body += chunk.toString(); });
-      req.on('end', () => {
-        try {
-          const data = JSON.parse(body);
-          const { channel, url, enabled, channel: channelName } = data;
-          
-          if (!channel || !['slack', 'discord', 'feishu'].includes(channel)) {
-            res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Invalid channel. Use: slack, discord, or feishu' }));
-            return;
-          }
-          
-          webhookConfigs[channel] = {
-            enabled: enabled !== undefined ? enabled : webhookConfigs[channel].enabled,
-            url: url || webhookConfigs[channel].url,
-            channel: channelName !== undefined ? channelName : webhookConfigs[channel].channel
-          };
-          
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ success: true, channel }));
-        } catch (err) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: err.message }));
-        }
-      });
-      return;
-    }
-
-    // Send Webhook Notification
-    if (req.url.startsWith('/api/webhooks/send') && req.method === 'POST') {
-      let body = '';
-      req.on('data', chunk => { body += chunk.toString(); });
-      req.on('end', async () => {
-        try {
-          const data = JSON.parse(body);
-          const { channel, message, title, color, fields } = data;
-          
-          if (!channel || !message) {
-            res.writeHead(400, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'Missing required fields: channel, message' }));
-            return;
-          }
-          
-          const result = await sendWebhookNotification(channel, message, { title, color, fields });
-          res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(result));
-        } catch (err) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: err.message }));
-        }
-      });
-      return;
-    }
-
     // GET: Return available alert endpoints
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({
       endpoints: [
-        'GET /api/alerts - Get all rules and history',
+        'GET /api/alerts - Get all alert rules and history',
         'POST /api/alerts/check - Check alert rules manually',
         'PATCH /api/alerts/:id - Update rule (enabled, threshold)',
         'DELETE /api/alerts/:id - Reset triggered alert',
         'POST /api/alerts/e2e - Record E2E test result'
       ]
     }));
+  } else if (req.url.startsWith('/api/webhooks/config') && req.method === 'GET') {
+    // Webhook Configuration Endpoint
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    // 隱藏敏感資訊
+    const safeConfigs = {};
+    for (const [channel, config] of Object.entries(webhookConfigs)) {
+      safeConfigs[channel] = {
+        enabled: config.enabled,
+        url: config.url ? '***configured***' : '',
+        channel: config.channel
+      };
+    }
+    res.end(JSON.stringify(safeConfigs));
+  } else if (req.url.startsWith('/api/webhooks/config') && req.method === 'PUT') {
+    // Update Webhook Configuration
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const { channel, url, enabled, channel: channelName } = data;
+        
+        if (!channel || !['slack', 'discord', 'feishu'].includes(channel)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid channel. Use: slack, discord, or feishu' }));
+          return;
+        }
+        
+        webhookConfigs[channel] = {
+          enabled: enabled !== undefined ? enabled : webhookConfigs[channel].enabled,
+          url: url || webhookConfigs[channel].url,
+          channel: channelName !== undefined ? channelName : webhookConfigs[channel].channel
+        };
+        
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true, channel }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+  } else if (req.url.startsWith('/api/webhooks/send') && req.method === 'POST') {
+    // Send Webhook Notification
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', async () => {
+      try {
+        const data = JSON.parse(body);
+        const { channel, message, title, color, fields } = data;
+        
+        if (!channel || !message) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Missing required fields: channel, message' }));
+          return;
+        }
+        
+        const result = await sendWebhookNotification(channel, message, { title, color, fields });
+        res.writeHead(result.success ? 200 : 400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
   } else {
     res.writeHead(404);
     res.end('Not Found');


### PR DESCRIPTION
## 變更內容
- 新增 Webhook 配置 API：
- 新增 Webhook 發送 API：
- 支援 Slack、Discord、飛書三種渠道
- 支援自定義標題、顏色、訊息內容

## API 使用方式
### 配置 Webhook
```
PUT /api/webhooks/config
{
  "channel": "slack",
  "url": "https://hooks.slack.com/services/xxx",
  "enabled": true
}
```

### 發送通知
```
POST /api/webhooks/send
{
  "channel": "slack",
  "message": "任務已完成",
  "title": "OpenClaw 通知",
  "color": "#36a64f"
}
```

## 測試方式
1. 配置 Webhook URL
2. 發送測試訊息驗證

## 相關 Issue
- #88