### PR TITLE
[編譯器] #107 即時通知 (Toast) 實作

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   })
   const { toasts, removeToast } = useToast()
   const prevCompletedTasksRef = useRef<CompletedTask[]>([])
+  const isFirstLoadRef = useRef(true) // 跳過首次載入的 Toast 顯示
   const loaderRef = useRef<HTMLDivElement>(null)
   const [showVisualAnnotation, setShowVisualAnnotation] = useState(false)
   const [showPromptInjection, setShowPromptInjection] = useState(false)
@@ -176,14 +177,18 @@ function App() {
           page: 1
         })
         
-        // 检测新完成的任务并显示 Toast
-        const prevTaskIds = new Set(prevCompletedTasksRef.current.map(t => t.id))
-        tasks.forEach(task => {
-          if (!prevTaskIds.has(task.id)) {
-            // 新完成的任务
-            showToast('success', `✅ 任務已完成: ${task.title}`)
-          }
-        })
+        // 检测新完成的任务并显示 Toast（跳过首次加载）
+        if (!isFirstLoadRef.current) {
+          const prevTaskIds = new Set(prevCompletedTasksRef.current.map(t => t.id))
+          tasks.forEach(task => {
+            if (!prevTaskIds.has(task.id)) {
+              // 新完成的任务
+              showToast('success', `✅ 任務已完成: ${task.title}`)
+            }
+          })
+        } else {
+          isFirstLoadRef.current = false
+        }
         
         // 更新 ref
         prevCompletedTasksRef.current = tasks


### PR DESCRIPTION
## 變更內容
- 實作任務完成時的 Toast 通知
- 使用 ref 追蹤已完成任務列表的變化
- 當檢測到新完成任務時顯示成功提示

## 測試方式
1. 啟動開發伺服器 `npm run dev`
2. 觀察已完成任務區塊載入時是否顯示 Toast 通知
3. 測試 Agent 狀態變化時的 Toast 通知

## 截圖
Toast 功能已在 Issue #90 Workflow Topology 合併後顯示過通知