### PR TITLE
[編譯器] #62 實作 Agent 控制確認對話框

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,12 @@ function App() {
   const loaderRef = useRef<HTMLDivElement>(null)
   const [showVisualAnnotation, setShowVisualAnnotation] = useState(false)
   const [showPromptInjection, setShowPromptInjection] = useState(false)
+  const [confirmDialog, setConfirmDialog] = useState<{
+    show: boolean
+    title: string
+    message: string
+    onConfirm: () => void
+  } | null>(null)
   const [injectionTargetAgent, setInjectionTargetAgent] = useState<{id: string, name: string, emoji: string} | null>(null)
   const [costMetrics, setCostMetrics] = useState<PerformanceMetrics['cost'] | null>(null)
   const [costLoading, setCostLoading] = useState(true)
@@ -297,18 +303,33 @@ function App() {
       restart: '重試',
     }
     
-    try {
-      const result = await controlAgent(agentId, action)
-      if (result.success) {
-        showToast('success', `${actionLabels[action]}指令已發送`)
-        // 刷新狀態
-        handleRefresh()
-      } else {
-        showToast('error', result.error || '操作失敗')
-      }
-    } catch (err) {
-      showToast('error', '操作失敗')
+    const confirmMessages: Record<AgentAction, { title: string; message: string }> = {
+      pause: { title: '確認暫停', message: `確定要暫停 Agent ${agentId} 嗎？` },
+      resume: { title: '確認恢復', message: `確定要恢復 Agent ${agentId} 嗎？` },
+      stop: { title: '確認終止', message: `確定要終止 Agent ${agentId} 嗎？此操作可能會中斷正在執行的任務。` },
+      restart: { title: '確認重試', message: `確定要重試 Agent ${agentId} 嗎？` },
     }
+    
+    const doAction = async () => {
+      try {
+        const result = await controlAgent(agentId, action)
+        if (result.success) {
+          showToast('success', `${actionLabels[action]}指令已發送`)
+          handleRefresh()
+        } else {
+          showToast('error', result.error || '操作失敗')
+        }
+      } catch (err) {
+        showToast('error', '操作失敗')
+      }
+    }
+    
+    setConfirmDialog({
+      show: true,
+      title: confirmMessages[action].title,
+      message: confirmMessages[action].message,
+      onConfirm: doAction,
+    })
   }
 
   // 打開提示注入面板
@@ -330,6 +351,32 @@ function App() {
   return (
     <div className="dashboard">
       <ToastContainer toasts={toasts} onRemove={removeToast} />
+      {/* Confirm Dialog */}
+      {confirmDialog?.show && (
+        <div className="modal-overlay" onClick={() => setConfirmDialog(null)}>
+          <div className="confirm-dialog" onClick={e => e.stopPropagation()}>
+            <div className="confirm-title">{confirmDialog.title}</div>
+            <div className="confirm-message">{confirmDialog.message}</div>
+            <div className="confirm-actions">
+              <button 
+                className="btn btn-cancel"
+                onClick={() => setConfirmDialog(null)}
+              >
+                取消
+              </button>
+              <button 
+                className="btn btn-confirm"
+                onClick={() => {
+                  confirmDialog.onConfirm()
+                  setConfirmDialog(null)
+                }}
+              >
+                確認
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* Header */}
       <header className="header">
         <div className="header-left">

--- a/src/index.css
+++ b/src/index.css
@@ -2107,3 +2107,76 @@ input:focus, textarea:focus, select:focus {
 .timeline-item.cancelled .timeline-dot {
   border-color: var(--text-muted);
 }
+
+/* Confirm Dialog */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: 24px;
+  min-width: 320px;
+  max-width: 400px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.confirm-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.confirm-message {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  margin-bottom: 24px;
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.confirm-actions .btn {
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.btn-cancel {
+  background: var(--bg-light);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.btn-cancel:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.btn-confirm {
+  background: var(--color-primary);
+  color: white;
+}
+
+.btn-confirm:hover {
+  filter: brightness(1.1);
+}


### PR DESCRIPTION
## 變更內容

- 為 Agent 控制按鈕（暫停、終止、重試）添加確認對話框
- 用戶點擊控制按鈕後需確認才能執行操作
- 新增 CSS 樣式美化確認對話框

## 測試方式

1. 點擊 Agent 卡片的控制按鈕
2. 應該彈出確認對話框
3. 點擊確認後才執行操作
4. 點擊取消則取消操作