### PR TITLE
[編譯器] #79 Agent 狀態卡片 - 修正離線顏色

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@
   /* Status Colors */
   --status-idle: #10B981;
   --status-busy: #F59E0B;
-  --status-offline: #EF4444;
+  --status-offline: #6B7280;
   --status-progress: #3B82F6;
   --status-completed: #8B5CF6;
   --status-blocked: #F59E0B;
@@ -251,7 +251,12 @@ body {
 }
 
 .agent-card.offline {
-  opacity: 0.6;
+  opacity: 0.7;
+  border-color: var(--status-offline);
+}
+
+.agent-card.offline .status-dot.offline {
+  background: var(--status-offline);
 }
 
 .agent-emoji {


### PR DESCRIPTION
## 變更內容
- 修正 Agent 卡片離線狀態顏色從紅色 (#EF4444) 改為灰色 (#6B7280)，符合設計需求：綠色=閒置、黃色=忙碌、灰色=離線

## 測試方式
1. 打開 Dashboard 頁面
2. 檢查 Agent 卡片狀態顏色是否正確顯示

## 截圖
離線狀態現在顯示為灰色而非紅色

## 相關 Issue
- #79 七 Agent 即時狀態卡片與視覺化