### PR TITLE
[編譯器] #67 思考鏈分層顯示與錯誤高亮

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ScoreLeaderboard } from './components/ScoreLeaderboard'
 import { PromptInjectionPanel } from './components/PromptInjection'
 import { ActivityTimeline } from './components/ActivityTimeline'
 import { WorkflowTopology } from './components/WorkflowTopology'
+import { ThinkingChainDisplay } from './components/ThinkingChainDisplay'
 import AlertHistory from './components/AlertHistory'
 
 // 項目類型
@@ -54,7 +55,7 @@ function App() {
   const [costMetrics, setCostMetrics] = useState<PerformanceMetrics['cost'] | null>(null)
   const [costLoading, setCostLoading] = useState(true)
   const [costDays, setCostDays] = useState(30)
-  const [activeTab, setActiveTab] = useState<'dashboard' | 'performance' | 'scores' | 'topology' | 'timeline' | 'alerts'>('dashboard')
+  const [activeTab, setActiveTab] = useState<'dashboard' | 'performance' | 'scores' | 'topology' | 'timeline' | 'alerts' | 'thinking'>('dashboard')
 
   useEffect(() => {
     // 初始載入
@@ -419,6 +420,12 @@ function App() {
             >
               🔔 警報歷史
             </button>
+            <button 
+              className={`nav-tab ${activeTab === 'thinking' ? 'active' : ''}`}
+              onClick={() => setActiveTab('thinking')}
+            >
+              🧠 思考鏈
+            </button>
           </nav>
         </div>
         <div className="header-actions">
@@ -652,6 +659,8 @@ function App() {
           <ActivityTimeline />
         ) : activeTab === 'alerts' ? (
           <AlertHistory maxHeight="calc(100vh - 140px)" />
+        ) : activeTab === 'thinking' ? (
+          <ThinkingChainDisplay maxHeight="calc(100vh - 140px)" />
         ) : (
           <PerformanceDashboard />
         )}

--- a/src/components/ThinkingChainDisplay.tsx
+++ b/src/components/ThinkingChainDisplay.tsx
@@ -1,0 +1,366 @@
+import { useState, useEffect, useRef } from 'react';
+import { 
+  type ThinkingChain, 
+  type ThinkingStep, 
+  type ThinkingChainDisplayProps,
+  STEP_CONFIG,
+  highlightSyntax,
+  containsError
+} from '../types/thinking-chain';
+
+// Agent information mapping
+const AGENT_INFO: Record<string, { name: string; emoji: string }> = {
+  'task-tracking': { name: '指揮台', emoji: '📋' },
+  'requirements': { name: '透析器', emoji: '🔍' },
+  'art-design': { name: '調色盤', emoji: '🎨' },
+  'engineering': { name: '編譯器', emoji: '⚙️' },
+  'art-review': { name: '鑑賞家', emoji: '🖼️' },
+  'feature-review': { name: '測試台', emoji: '🧪' },
+  'devops': { name: '部署艦', emoji: '🚀' },
+};
+
+// Generate mock thinking chain for demo
+function generateMockThinkingChain(): ThinkingChain {
+  const steps: ThinkingStep[] = [
+    {
+      id: '1',
+      type: 'thought',
+      content: '我需要完成這個 GitHub Issue #67 - 實現思考鏈分層顯示功能。讓我先分析需求：1) 分層顯示 Thought/Action/Observation，2) 錯誤自動高亮，3) 語法著色。',
+      timestamp: new Date(Date.now() - 300000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '2',
+      type: 'action',
+      content: '創建思考鏈類型定義',
+      timestamp: new Date(Date.now() - 280000).toISOString(),
+      agentId: 'engineering',
+      toolName: 'write',
+      toolInput: { path: 'src/types/thinking-chain.ts' },
+    },
+    {
+      id: '3',
+      type: 'observation',
+      content: '成功創建類型定義文件，包含 ThinkingStep、ThinkingChain 接口和 STEP_CONFIG 配置。',
+      timestamp: new Date(Date.now() - 260000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '4',
+      type: 'thought',
+      content: '現在需要創建顯示組件。考慮使用 Accordion 樣式來折疊/展開每個步驟，並且對錯誤內容進行高亮處理。',
+      timestamp: new Date(Date.now() - 240000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '5',
+      type: 'action',
+      content: '創建 ThinkingChainDisplay 組件',
+      timestamp: new Date(Date.now() - 220000).toISOString(),
+      agentId: 'engineering',
+      toolName: 'write',
+      toolInput: { path: 'src/components/ThinkingChainDisplay.tsx' },
+    },
+    {
+      id: '6',
+      type: 'error',
+      content: 'TypeError: Cannot read property "map" of undefined',
+      timestamp: new Date(Date.now() - 200000).toISOString(),
+      agentId: 'engineering',
+      error: '嘗試渲染 steps 時，發現 steps 可能為 undefined。需要添加空值檢查。',
+    },
+    {
+      id: '7',
+      type: 'thought',
+      content: '需要添加防禦性編程，檢查 steps 是否存在。如果不存在，顯示空狀態提示。',
+      timestamp: new Date(Date.now() - 180000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '8',
+      type: 'action',
+      content: '修復組件中的空值處理',
+      timestamp: new Date(Date.now() - 160000).toISOString(),
+      agentId: 'engineering',
+      toolName: 'edit',
+      toolInput: { path: 'src/components/ThinkingChainDisplay.tsx' },
+    },
+    {
+      id: '9',
+      type: 'observation',
+      content: '修復後組件正常運作。添加了 steps?.map() 可選鏈操作，並添加了 loading 和 empty 狀態。',
+      timestamp: new Date(Date.now() - 140000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '10',
+      type: 'thought',
+      content: '現在需要添加語法高亮功能。使用基本的正則表達式來識別字符串、數字、關鍵字等。',
+      timestamp: new Date(Date.now() - 120000).toISOString(),
+      agentId: 'engineering',
+    },
+    {
+      id: '11',
+      type: 'action',
+      content: '實現 highlightSyntax 函數',
+      timestamp: new Date(Date.now() - 100000).toISOString(),
+      agentId: 'engineering',
+      toolName: 'write',
+      toolInput: { path: 'src/types/thinking-chain.ts' },
+    },
+    {
+      id: '12',
+      type: 'result',
+      content: '完成思考鏈顯示功能的開發，包括：類型定義、顯示組件、語法高亮、錯誤高亮。',
+      timestamp: new Date(Date.now() - 60000).toISOString(),
+      agentId: 'engineering',
+    },
+  ];
+
+  return {
+    taskId: '#67',
+    agentId: 'engineering',
+    steps,
+    status: 'completed',
+    startTime: new Date(Date.now() - 300000).toISOString(),
+    endTime: new Date(Date.now() - 60000).toISOString(),
+  };
+}
+
+// Format timestamp
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString('zh-TW', { 
+    hour: '2-digit', 
+    minute: '2-digit',
+    second: '2-digit'
+  });
+}
+
+// Calculate duration
+function formatDuration(startTime: string, endTime?: string): string {
+  const start = new Date(startTime).getTime();
+  const end = endTime ? new Date(endTime).getTime() : Date.now();
+  const duration = Math.floor((end - start) / 1000);
+  
+  if (duration < 60) return `${duration}秒`;
+  if (duration < 3600) return `${Math.floor(duration / 60)}分${duration % 60}秒`;
+  return `${Math.floor(duration / 3600)}小時${Math.floor((duration % 3600) / 60)}分`;
+}
+
+// Step content renderer with syntax highlighting
+function StepContent({ step, isCollapsed, onToggle }: { 
+  step: ThinkingStep; 
+  isCollapsed: boolean;
+  onToggle: () => void;
+}) {
+  const config = STEP_CONFIG[step.type];
+  const hasError = step.type === 'error' || containsError(step.content);
+  
+  // Check if content looks like code
+  const isCode = step.content.includes('{') || 
+                 step.content.includes('function') || 
+                 step.content.includes('=>') ||
+                 step.toolName;
+
+  return (
+    <div 
+      className={`thinking-step ${step.type} ${hasError ? 'has-error' : ''}`}
+      style={{ 
+        borderLeftColor: config.color,
+        backgroundColor: hasError ? 'rgba(239, 68, 68, 0.08)' : config.bgColor
+      }}
+    >
+      <div className="step-header" onClick={onToggle}>
+        <div className="step-type" style={{ color: config.color }}>
+          <span className="step-icon">{config.icon}</span>
+          <span className="step-label">{config.label}</span>
+        </div>
+        <div className="step-meta">
+          <span className="step-time">{formatTime(step.timestamp)}</span>
+          <button className="step-toggle">
+            {isCollapsed ? '▼' : '▲'}
+          </button>
+        </div>
+      </div>
+      
+      {!isCollapsed && (
+        <div className="step-content">
+          {isCode ? (
+            <pre 
+              className="step-code"
+              dangerouslySetInnerHTML={{ 
+                __html: highlightSyntax(step.content) 
+              }}
+            />
+          ) : (
+            <p className="step-text">{step.content}</p>
+          )}
+          
+          {/* Tool information */}
+          {step.toolName && (
+            <div className="step-tool">
+              <span className="tool-label">工具:</span>
+              <code className="tool-name">{step.toolName}</code>
+              {step.toolInput && (
+                <details className="tool-input">
+                  <summary>輸入</summary>
+                  <pre>{JSON.stringify(step.toolInput, null, 2)}</pre>
+                </details>
+              )}
+            </div>
+          )}
+          
+          {/* Error details */}
+          {step.error && (
+            <div className="step-error">
+              <span className="error-label">錯誤分析:</span>
+              <p>{step.error}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ThinkingChainDisplay({ 
+  chain: initialChain, 
+  maxHeight = '600px',
+  showAgentInfo = true,
+  autoScroll = true 
+}: ThinkingChainDisplayProps) {
+  const [chain, setChain] = useState<ThinkingChain | null>(initialChain || null);
+  const [loading, setLoading] = useState(!initialChain);
+  const [collapsedSteps, setCollapsedSteps] = useState<Set<string>>(new Set());
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Simulate loading
+    if (!initialChain) {
+      setTimeout(() => {
+        setChain(generateMockThinkingChain());
+        setLoading(false);
+      }, 500);
+    }
+  }, [initialChain]);
+
+  // Auto-scroll to bottom when new steps are added
+  useEffect(() => {
+    if (autoScroll && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [chain?.steps, autoScroll]);
+
+  const toggleStep = (stepId: string) => {
+    setCollapsedSteps(prev => {
+      const next = new Set(prev);
+      if (next.has(stepId)) {
+        next.delete(stepId);
+      } else {
+        next.add(stepId);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = (collapse: boolean) => {
+    if (collapse) {
+      setCollapsedSteps(new Set(chain?.steps.map(s => s.id) || []));
+    } else {
+      setCollapsedSteps(new Set());
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="thinking-chain loading">
+        <div className="loading-spinner">載入思考鏈...</div>
+      </div>
+    );
+  }
+
+  if (!chain) {
+    return (
+      <div className="thinking-chain empty">
+        <div className="empty-state">暫無思考鏈數據</div>
+      </div>
+    );
+  }
+
+  const agent = AGENT_INFO[chain.agentId];
+  const errorCount = chain.steps.filter(s => s.type === 'error' || containsError(s.content)).length;
+
+  return (
+    <div className="thinking-chain" style={{ maxHeight }}>
+      {/* Header */}
+      <div className="chain-header">
+        <div className="chain-info">
+          {showAgentInfo && agent && (
+            <span className="chain-agent">
+              {agent.emoji} {agent.name}
+            </span>
+          )}
+          <span className="chain-task">{chain.taskId}</span>
+          <span className={`chain-status ${chain.status}`}>
+            {chain.status === 'running' && '🔄 執行中'}
+            {chain.status === 'completed' && '✅ 完成'}
+            {chain.status === 'failed' && '❌ 失敗'}
+          </span>
+        </div>
+        <div className="chain-meta">
+          <span className="chain-duration">
+            ⏱️ {formatDuration(chain.startTime, chain.endTime)}
+          </span>
+          {errorCount > 0 && (
+            <span className="chain-errors" title={`${errorCount} 個錯誤`}>
+              ⚠️ {errorCount}
+            </span>
+          )}
+          <button 
+            className="chain-toggle-all"
+            onClick={() => toggleAll(collapsedSteps.size === 0)}
+            title={collapsedSteps.size === 0 ? '全部折疊' : '全部展開'}
+          >
+            {collapsedSteps.size === 0 ? '⬆️ 折疊' : '⬇️ 展開'}
+          </button>
+        </div>
+      </div>
+
+      {/* Steps */}
+      <div className="chain-steps" ref={containerRef}>
+        {chain.steps.map((step) => (
+          <StepContent
+            key={step.id}
+            step={step}
+            isCollapsed={collapsedSteps.has(step.id)}
+            onToggle={() => toggleStep(step.id)}
+          />
+        ))}
+      </div>
+
+      {/* Footer summary */}
+      <div className="chain-footer">
+        <div className="chain-stats">
+          <span>🧠 {chain.steps.filter(s => s.type === 'thought').length} 思考</span>
+          <span>⚡ {chain.steps.filter(s => s.type === 'action').length} 行動</span>
+          <span>👁️ {chain.steps.filter(s => s.type === 'observation').length} 觀察</span>
+          {errorCount > 0 && (
+            <span className="error-stat">❌ {errorCount} 錯誤</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Compact version for embedding in other components
+export function ThinkingChainPanel() {
+  return (
+    <div className="thinking-chain-panel">
+      <ThinkingChainDisplay maxHeight="calc(100vh - 200px)" />
+    </div>
+  );
+}
+
+export default ThinkingChainDisplay;

--- a/src/index.css
+++ b/src/index.css
@@ -2185,3 +2185,340 @@ input:focus, textarea:focus, select:focus {
 .btn-confirm:hover {
   filter: brightness(1.1);
 }
+
+/* ============================================
+   Thinking Chain Display - 思考鏈分層顯示
+   ============================================ */
+
+.thinking-chain {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.thinking-chain.loading,
+.thinking-chain.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: var(--text-muted);
+}
+
+/* Chain Header */
+.chain-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: var(--bg-light);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.chain-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chain-agent {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.chain-task {
+  padding: 2px 8px;
+  background: var(--bg-card);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.chain-status {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.chain-status.running {
+  background: rgba(59, 130, 246, 0.2);
+  color: #3B82F6;
+}
+
+.chain-status.completed {
+  background: rgba(16, 185, 129, 0.2);
+  color: #10B981;
+}
+
+.chain-status.failed {
+  background: rgba(239, 68, 68, 0.2);
+  color: #EF4444;
+}
+
+.chain-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chain-duration {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.chain-errors {
+  padding: 2px 8px;
+  background: rgba(239, 68, 68, 0.2);
+  border-radius: 10px;
+  font-size: 12px;
+  color: #EF4444;
+  font-weight: 600;
+}
+
+.chain-toggle-all {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.chain-toggle-all:hover {
+  background: var(--bg-light);
+  color: var(--text-primary);
+}
+
+/* Chain Steps */
+.chain-steps {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+/* Individual Step */
+.thinking-step {
+  border-left: 3px solid;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  overflow: hidden;
+  transition: all 0.2s;
+}
+
+.thinking-step:hover {
+  transform: translateX(2px);
+}
+
+.thinking-step.has-error {
+  border-left-width: 4px;
+}
+
+.step-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.step-header:hover {
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.step-type {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.step-icon {
+  font-size: 14px;
+}
+
+.step-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.step-time {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.step-toggle {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 2px;
+}
+
+.step-content {
+  padding: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.step-text {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.step-code {
+  font-family: 'Fira Code', 'Consolas', monospace;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Syntax highlighting */
+.syntax-string {
+  color: #22C55E;
+}
+
+.syntax-number {
+  color: #F59E0B;
+}
+
+.syntax-keyword {
+  color: #8B5CF6;
+}
+
+.syntax-comment {
+  color: #6B7280;
+  font-style: italic;
+}
+
+.syntax-function {
+  color: #3B82F6;
+}
+
+/* Tool information */
+.step-tool {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 12px;
+}
+
+.tool-label {
+  color: var(--text-muted);
+  margin-right: 6px;
+}
+
+.tool-name {
+  padding: 2px 6px;
+  background: rgba(59, 130, 246, 0.2);
+  border-radius: 4px;
+  color: #3B82F6;
+  font-family: monospace;
+}
+
+.tool-input {
+  margin-top: 8px;
+}
+
+.tool-input summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.tool-input pre {
+  margin-top: 6px;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  font-size: 11px;
+  overflow-x: auto;
+}
+
+/* Error styling */
+.step-error {
+  margin-top: 12px;
+  padding: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 6px;
+  border-left: 3px solid #EF4444;
+}
+
+.error-label {
+  display: block;
+  font-weight: 600;
+  color: #EF4444;
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.step-error p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* Chain Footer */
+.chain-footer {
+  padding: 12px 16px;
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+}
+
+.chain-stats {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.chain-stats .error-stat {
+  color: #EF4444;
+  font-weight: 600;
+}
+
+/* Panel variant */
+.thinking-chain-panel {
+  height: 100%;
+  overflow: hidden;
+}
+
+.thinking-chain-panel .thinking-chain {
+  height: 100%;
+  border: none;
+  border-radius: 0;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .chain-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  
+  .chain-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+  
+  .chain-stats {
+    gap: 8px;
+    font-size: 11px;
+  }
+}

--- a/src/types/thinking-chain.ts
+++ b/src/types/thinking-chain.ts
@@ -1,0 +1,123 @@
+/**
+ * Thinking Chain Types
+ * ReAct pattern: Thought → Action → Observation
+ */
+
+export type ChainStepType = 'thought' | 'action' | 'observation' | 'error' | 'result';
+
+export interface ThinkingStep {
+  id: string;
+  type: ChainStepType;
+  content: string;
+  timestamp: string;
+  agentId?: string;
+  toolName?: string;
+  toolInput?: Record<string, unknown>;
+  toolOutput?: string;
+  error?: string;
+  isCollapsed?: boolean;
+}
+
+export interface ThinkingChain {
+  taskId: string;
+  agentId: string;
+  steps: ThinkingStep[];
+  status: 'running' | 'completed' | 'failed';
+  startTime: string;
+  endTime?: string;
+}
+
+export interface ThinkingChainDisplayProps {
+  chain?: ThinkingChain;
+  maxHeight?: string;
+  showAgentInfo?: boolean;
+  autoScroll?: boolean;
+}
+
+/**
+ * Step type to display configuration
+ */
+export const STEP_CONFIG: Record<ChainStepType, { 
+  label: string; 
+  icon: string; 
+  color: string; 
+  bgColor: string;
+}> = {
+  thought: { 
+    label: '思考', 
+    icon: '🧠', 
+    color: '#8B5CF6',
+    bgColor: 'rgba(139, 92, 246, 0.1)'
+  },
+  action: { 
+    label: '行動', 
+    icon: '⚡', 
+    color: '#3B82F6',
+    bgColor: 'rgba(59, 130, 246, 0.1)'
+  },
+  observation: { 
+    label: '觀察', 
+    icon: '👁️', 
+    color: '#10B981',
+    bgColor: 'rgba(16, 185, 129, 0.1)'
+  },
+  error: { 
+    label: '錯誤', 
+    icon: '❌', 
+    color: '#EF4444',
+    bgColor: 'rgba(239, 68, 68, 0.15)'
+  },
+  result: { 
+    label: '結果', 
+    icon: '✅', 
+    color: '#22C55E',
+    bgColor: 'rgba(34, 197, 94, 0.1)'
+  },
+};
+
+/**
+ * Syntax highlighting for code blocks
+ */
+export function highlightSyntax(code: string): string {
+  // Basic syntax highlighting patterns
+  const patterns: Array<[RegExp, string]> = [
+    // Strings
+    [/(["'])(?:(?!\1)[^\\]|\\.)*\1/g, '<span class="syntax-string">$&</span>'],
+    // Numbers
+    [/\b(\d+\.?\d*)\b/g, '<span class="syntax-number">$1</span>'],
+    // Keywords
+    [/\b(const|let|var|function|return|if|else|for|while|class|import|export|from|async|await|try|catch|throw|new|this|typeof|instanceof)\b/g, '<span class="syntax-keyword">$1</span>'],
+    // Comments
+    [/\/\/.*$/gm, '<span class="syntax-comment">$&</span>'],
+    [/\/\*[\s\S]*?\*\//g, '<span class="syntax-comment">$&</span>'],
+    // Function calls
+    [/\b([a-zA-Z_]\w*)\s*\(/g, '<span class="syntax-function">$1</span>('],
+  ];
+
+  let result = code;
+  for (const [pattern, replacement] of patterns) {
+    result = result.replace(pattern, replacement);
+  }
+  
+  return result;
+}
+
+/**
+ * Check if content contains error/exception
+ */
+export function containsError(content: string): boolean {
+  const errorPatterns = [
+    /error/i,
+    /exception/i,
+    /fail/i,
+    /cannot/i,
+    /unable to/i,
+    /undefined/i,
+    /null/i,
+    /TypeError/i,
+    /ReferenceError/i,
+    /SyntaxError/i,
+  ];
+  
+  return errorPatterns.some(pattern => pattern.test(content));
+}


### PR DESCRIPTION
## 變更內容

實現 Issue #67 - 思考鏈分層顯示與錯誤高亮功能

### 新增功能
1. **思考鏈類型定義** (`src/types/thinking-chain.ts`)
   - ThinkingChain 和 ThinkingStep 接口
   - ReAct 模式類型：thought, action, observation, error, result
   
2. **思考鏈顯示組件** (`src/components/ThinkingChainDisplay.tsx`)
   - 分層顯示思考過程
   - 錯誤自動高亮
   - 語法著色
   - 步驟折疊/展開功能

3. **Dashboard 整合**
   - 新增「思考鏈」Tab

### 測試方式
1. 啟動開發伺服器：npm run dev
2. 進入 Dashboard，點擊「思考鏈」Tab
3. 查看思考鏈顯示效果
