### PR TITLE
[編譯器] #123 部署 Dashboard 到生產環境

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,28 @@
+# Deployment Log - 2026-03-16
+
+## Task: #123 部署：Dashboard 服務部署
+
+### 執行情況
+
+**時間:** 2026-03-16 08:53 AM (Asia/Shanghai)
+
+**分支:** feature/123-dashboard-deployment
+
+**執行動作:**
+1. ✅ 確認依賴 (#121, #122) 已完成
+2. ✅ 執行 `npm run build` - 構建成功
+   - dist/index.html: 0.47 kB
+   - dist/assets/index-CU8TSSVo.css: 36.01 kB
+   - dist/assets/index-DV-LPNRz.js: 214.45 kB
+3. ✅ 執行 `bash scripts/stable-server.sh start` - 服務上線
+4. ✅ 驗證 HTTP 200 響應
+
+**部署結果:**
+- 服務名稱: openclaw-dashboard-stable
+- 端口: 28080
+- 狀態: online
+- URL: http://localhost:28080
+
+### 備註
+- 這是一個重新部署任務，服務之前已存在於 PM2 中
+- 本次執行 restart 來加載最新的 build 產物


### PR DESCRIPTION
## 變更內容
- 部署 Dashboard 到生產環境 (port 28080)
- 新增 DEPLOYMENT.md 部署記錄

## 測試方式
- 訪問 http://localhost:28080 確認服務正常運行
- 執行 `pm2 list` 確認服務狀態為 online

## 截圖
N/A (後端部署任務)