### PR TITLE
[編譯器] #27 Add auto-tagging workflow for Epic issues

### DIFF
--- a/.github/workflows/auto-tagging.yml
+++ b/.github/workflows/auto-tagging.yml
@@ -1,0 +1,26 @@
+name: Auto Tagging
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'Epic') && contains(github.event.issue.labels.*.name, 'Done')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create git tag
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number }}
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          TAG_NAME="epic-${ISSUE_NUMBER}-${TIMESTAMP}"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a "$TAG_NAME" -m "Epic #$ISSUE_NUMBER closed"
+          git push origin "$TAG_NAME"


### PR DESCRIPTION
## 變更內容
- 新增 GitHub Actions workflow：auto-tagging.yml
- 當 Epic 類型的 issue 被關閉時，自動執行 git tag
- tag 命名格式：epic-{issue_number}-{timestamp}

## 測試方式
1. 創建一個帶有 "Epic" 和 "Done" 標籤的 issue
2. 關閉該 issue
3. 確認 GitHub Actions 自動創建了 git tag

## 截圖
N/A

## 驗收標準
- [x] 建立 GitHub Actions workflow
- [x] 當 issue 加上 Epic + Done 標籤並被關閉時，自動執行 git tag
- [x] tag 命名格式：epic-{issue_number}-{timestamp}