### PR TITLE
[部署艦] 修復 auto-tagging workflow

### DIFF
--- a/.github/workflows/auto-tagging.yml
+++ b/.github/workflows/auto-tagging.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'Epic') && contains(github.event.issue.labels.*.name, 'Done')
+    if: contains(github.event.issue.labels.*.name, 'Epic')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 問題
- Workflow 需要 "Epic" + "Done" 兩個 label，但 "Done" label 不存在
- 導致 Epic 關閉時無法自動執行 git tag

## 解決方案
- 移除 "Done" label 的需求，因為 workflow 本身已經在 issue closed 時觸發
- 只要 issue 有 "Epic" label 且被關閉，就會自動建立 git tag

## 測試
- 可手動關閉一個帶有 Epic label 的 issue 來測試