### PR TITLE
[編譯器] #164 修復 Agent 狀態顯示為離線的問題

### DIFF
--- a/src/services/api/agentStatus.ts
+++ b/src/services/api/agentStatus.ts
@@ -24,12 +24,28 @@ const AGENT_MEMBERS = [
 
 // 從 sessions_list API 回應映射狀態
 function mapSessionToStatus(session: any): AgentStatus['status'] {
-  if (!session || session.activeMinutes === undefined) {
+  if (!session) {
     return 'offline'
   }
-  // 有最近活動的 session 視為 idle 或 busy
-  // 這是簡單的判斷邏輯，實際應根據 session 內容更精確判斷
+  
+  // 檢查 session key 中是否包含有效的 agent ID
+  // key 格式: agent:engineering:cron:xxx 或 agent:requirements:session:xxx
+  const key = session.key || ''
+  if (!key.startsWith('agent:')) {
+    return 'offline'
+  }
+  
+  // 有 session key 就視為 idle（Agent 存在但當前沒有執行任務）
+  // 實際的 "忙碌" 狀態應該由 run: 子 session 來判斷，這裡簡化為 idle
   return 'idle'
+}
+
+// 從 session key 提取 agent ID
+function extractAgentId(sessionKey: string): string | null {
+  if (!sessionKey) return null
+  // key 格式: agent:engineering:cron:xxx → engineering
+  const match = sessionKey.match(/^agent:([^:]+):/)
+  return match ? match[1] : null
 }
 
 // 獲取所有 Agent 的狀態
@@ -46,7 +62,11 @@ export async function fetchAgentStatuses(): Promise<AgentStatus[]> {
     
     // 將 sessions 映射到 Agent 狀態
     return AGENT_MEMBERS.map(member => {
-      const session = sessions.find((s: any) => s.label === member.id || s.agentId === member.id)
+      // 從 sessions key 中查找匹配的 agent
+      const session = sessions.find((s: any) => {
+        const sessionAgentId = extractAgentId(s.key)
+        return sessionAgentId === member.id
+      })
       
       return {
         id: member.id,


### PR DESCRIPTION
## 變更內容

- 修復 session key 解析邏輯，正確提取 agent ID
- 將狀態判斷改為「有任何 session 記錄即為 idle」
- 修復後所有 7 個 Agent 正確顯示為「閒置」而非「離線」

## 測試方式

1. 開啟 http://localhost:3000
2. 點擊「依賴拓撲」或查看首頁
3. 確認所有 7 個 Agent 狀態為「閒置」

## 交互自測結果

✅ 所有 Agent（指揮台、透析器、調色盤、編譯器、鑑賞家、測試台、部署艦）均顯示為「閒置」狀態
✅ 控制按鈕已啟用（非 disabled）