### PR TITLE
[編譯器] 修復績效看板 API 代理與主題切換問題

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,8 @@
   --bg-dark: #F5F7FA;
   --bg-card: #FFFFFF;
   --bg-light: #E8ECF1;
+  --bg-primary: #F5F7FA;
+  --bg-secondary: #FFFFFF;
   --border: #D1D9E6;
   
   --text-primary: #1A1D21;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,18 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      '/api/performance': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/api/scores': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/api/agent': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## 修復內容

### Issue #166: 績效看板數據加載失敗
- **原因**: Vite 配置缺少 /api/performance 等 API 端點的代理設置
- **修復**: 在 vite.config.ts 中添加 /api/performance、/api/scores、/api/agent 的代理配置

### Issue #165: 主題切換按鈕無效
- **原因**: Light Theme CSS 變量缺少 --bg-primary 和 --bg-secondary 定義
- **修復**: 在 src/index.css 的 [data-theme="light"] 中添加這些變量

## 交互自測結果
- 點擊「績效看板」導航，正常顯示團隊概覽、Agent 排行榜、活動熱度圖、空轉分析
- 點擊主題切換按鈕，背景色從深色 (rgb(10, 14, 23)) 變為淺色 (rgb(245, 247, 250))
- 刷新頁面後，主題狀態正確保存到 localStorage
