### PR TITLE
[Task] 硬編碼掃描儀 CLI 工具

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,74 @@
+# ENVIRONMENT.md - 環境配置標準
+
+本文檔定義了環境變數、配置和硬編碼規則，以確保 Codebase 的一致性和可維護性。
+
+## 端口配置
+
+| 服務 | 環境變數 | 預設值 | 允許值 |
+|------|---------|--------|--------|
+| API 伺服器 | `PORT` | `3001` | 需透過環境變數覆蓋 |
+| 前端開發 | `VITE_PORT` | `5173` | 需透過環境變數覆蓋 |
+| 測試伺服器 | `TEST_PORT` | `3002` | 需透過環境變數覆蓋 |
+
+**禁止硬編碼端口號** - 必須使用環境變數或配置文件。
+
+## 環境變數
+
+### 必要環境變數
+- `PORT` - API 伺服器端口
+- `GITHUB_TOKEN` - GitHub API 權杖
+- `OPENCLAW_API_URL` - OpenClaw API 端點
+
+### 可選環境變數
+- `LOG_LEVEL` - 日誌級別 (debug/info/warn/error)
+- `CACHE_TTL` - 快取存活時間 (毫秒)
+- `SESSION_TIMEOUT` - 會話超時時間 (毫秒)
+
+## URL 配置
+
+- 所有 API URL 必須透過環境變數配置
+- 禁止在程式碼中硬編碼 API 端點
+- 建議使用相对路径或通过配置服务获取
+
+## 掃描規則
+
+本專案使用硬編碼掃描儀 (Hardcoded Scanner) 自動檢測違規。規則如下：
+
+### 1. 端口硬編碼 (PORT_PATTERN)
+```regex
+\b(3000|3001|3002|8080|5173)\b
+```
+**例外**: 注释中的人类可读说明文字
+
+### 2. URL 硬編碼 (URL_PATTERN)
+```regex
+https?://(?!{{{{|ENV_|VITE_|).*\.(com|io|org|net|cn|hk)
+```
+**例外**: localhost、127.0.0.1
+
+### 3. API Key 硬編碼 (APIKEY_PATTERN)
+```regex
+(api[_-]?key|token|secret|password|pwd)['":\s=]+['"][a-zA-Z0-9_-]{20,}['"]
+```
+
+### 4. 環境變數直接引用 (ENV_PATTERN)
+```regex
+process\.env\.(?!PORT|GITHUB_TOKEN|OPENCLAW_API_URL|VITE_)
+```
+
+## CI/CD 整合
+
+硬編碼掃描儀可透過以下方式整合到 CI/CD：
+
+```bash
+# 運行掃描
+npm run scan:hardcoded
+
+# 掃描並生成報告
+npm run scan:hardcoded -- --format=json --output=reports/hardcoded.json
+```
+
+退出碼：
+- `0` - 無違規或只有警告
+- `1` - 發現錯誤級別違規
+- `2` - 掃描執行失敗

--- a/scripts/hardcoded-scanner.js
+++ b/scripts/hardcoded-scanner.js
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+/**
+ * Hardcoded Scanner CLI Tool
+ * 掃描 Codebase 中違反 ENVIRONMENT.md 的硬編碼
+ * 
+ * Usage:
+ *   node scripts/hardcoded-scanner.js [--format=json|text] [--output=path] [--fix]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Scanner rules based on ENVIRONMENT.md
+const RULES = {
+  // Port hardcoding: 3000, 3001, 3002, 8080, 5173
+  PORT: {
+    name: 'Port Hardcoding',
+    pattern: /\b(3000|3001|3002|8080|5173)\b/g,
+    severity: 'error',
+    description: 'Hardcoded port number found. Use environment variables instead.'
+  },
+  
+  // URL hardcoding (excluding localhost, ENV vars, VITE_ prefixes)
+  URL: {
+    name: 'URL Hardcoding',
+    pattern: /https?:\/\/(?!localhost|127\.0\.0\.1|{{\.|{{\{|ENV_|VITE_|REACT_APP_)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+    severity: 'error',
+    description: 'Hardcoded URL found. Use environment variables or config files.'
+  },
+  
+  // API Key / Token patterns
+  APIKEY: {
+    name: 'API Key/Token',
+    pattern: /(api[_-]?key|token|secret|password|pwd|auth)['":\s=]+['"][a-zA-Z0-9_\-]{16,}['"]/gi,
+    severity: 'critical',
+    description: 'Potential hardcoded API key or token found.'
+  },
+  
+  // Direct process.env access without allowed list
+  ENV: {
+    name: 'Direct Environment Access',
+    pattern: /process\.env\.(?!PORT|GITHUB_TOKEN|OPENCLAW_API_URL|VITE_|NODE_ENV|LOG_LEVEL|CACHE_TTL|SESSION_TIMEOUT)[A-Z_]+/g,
+    severity: 'warning',
+    description: 'Direct process.env access. Consider adding to ENVIRONMENT.md allowed list.'
+  }
+};
+
+// Directories and files to scan
+const SCAN_TARGETS = [
+  'server',
+  'src',
+  'scripts'
+];
+
+// Files and patterns to exclude
+const EXCLUDE_PATTERNS = [
+  /node_modules/,
+  /\.git/,
+  /dist/,
+  /\.vite/,
+  /logs/,
+  /temp/,
+  /ENVIRONMENT\.md/,
+  /hardcoded-scanner\.js/
+];
+
+// File extensions to scan
+const SCAN_EXTENSIONS = ['.js', '.ts', '.tsx', '.jsx', '.json', '.env', '.env.example'];
+
+/**
+ * Find all files to scan
+ */
+function findFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    
+    // Skip excluded patterns
+    if (EXCLUDE_PATTERNS.some(pattern => pattern.test(fullPath))) {
+      continue;
+    }
+    
+    if (entry.isDirectory()) {
+      findFiles(fullPath, files);
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name);
+      if (SCAN_EXTENSIONS.includes(ext) || entry.name.startsWith('.env')) {
+        files.push(fullPath);
+      }
+    }
+  }
+  
+  return files;
+}
+
+/**
+ * Scan a single file for violations
+ */
+function scanFile(filePath) {
+  const violations = [];
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  
+  for (const [ruleKey, rule] of Object.entries(RULES)) {
+    // Reset regex lastIndex
+    rule.pattern.lastIndex = 0;
+    
+    // Find all matches
+    let match;
+    while ((match = rule.pattern.exec(content)) !== null) {
+      // Calculate line number
+      const lineNumber = content.substring(0, match.index).split('\n').length;
+      const line = lines[lineNumber - 1]?.trim() || '';
+      
+      // Skip comments explaining the value
+      if (line.match(/^\/\/.*example|^\/\*.*example|^\s*\*|^\s*#/)) {
+        continue;
+      }
+      
+      violations.push({
+        rule: ruleKey,
+        name: rule.name,
+        severity: rule.severity,
+        description: rule.description,
+        file: filePath,
+        line: lineNumber,
+        content: line,
+        match: match[0]
+      });
+    }
+  }
+  
+  return violations;
+}
+
+/**
+ * Main scanner function
+ */
+function scan(options = {}) {
+  console.log('🔍 Hardcoded Scanner');
+  console.log('====================\n');
+  
+  const allFiles = [];
+  
+  // Find files to scan
+  for (const target of SCAN_TARGETS) {
+    const targetPath = path.join(process.cwd(), target);
+    if (fs.existsSync(targetPath)) {
+      findFiles(targetPath, allFiles);
+    }
+  }
+  
+  console.log(`Scanning ${allFiles.length} files...\n`);
+  
+  const allViolations = [];
+  let scannedCount = 0;
+  
+  for (const file of allFiles) {
+    const violations = scanFile(file);
+    if (violations.length > 0) {
+      allViolations.push(...violations);
+    }
+    scannedCount++;
+  }
+  
+  // Summary by severity
+  const summary = {
+    critical: 0,
+    error: 0,
+    warning: 0
+  };
+  
+  for (const v of allViolations) {
+    summary[v.severity]++;
+  }
+  
+  // Output results
+  if (options.format === 'json') {
+    const result = {
+      summary,
+      violations: allViolations,
+      scannedFiles: scannedCount,
+      timestamp: new Date().toISOString()
+    };
+    
+    if (options.output) {
+      fs.writeFileSync(options.output, JSON.stringify(result, null, 2));
+      console.log(`📄 Report saved to: ${options.output}`);
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+  } else {
+    // Text format
+    console.log('📊 Summary');
+    console.log('─'.repeat(40));
+    console.log(`  🔴 Critical: ${summary.critical}`);
+    console.log(`  🟠 Error:   ${summary.error}`);
+    console.log(`  🟡 Warning: ${summary.warning}`);
+    console.log(`  📁 Files:   ${scannedCount}`);
+    console.log('');
+    
+    if (allViolations.length > 0) {
+      console.log('⚠️  Violations Found');
+      console.log('─'.repeat(40));
+      
+      // Group by file
+      const byFile = {};
+      for (const v of allViolations) {
+        if (!byFile[v.file]) byFile[v.file] = [];
+        byFile[v.file].push(v);
+      }
+      
+      for (const [file, violations] of Object.entries(byFile)) {
+        const relativePath = path.relative(process.cwd(), file);
+        console.log(`\n📄 ${relativePath}`);
+        for (const v of violations) {
+          const emoji = v.severity === 'critical' ? '🔴' : v.severity === 'error' ? '🟠' : '🟡';
+          console.log(`  ${emoji} Line ${v.line}: [${v.name}] ${v.match}`);
+          console.log(`      ${v.description}`);
+        }
+      }
+    } else {
+      console.log('✅ No violations found!');
+    }
+  }
+  
+  // Exit code based on severity
+  if (summary.critical > 0 || summary.error > 0) {
+    process.exit(1);
+  }
+  
+  return allViolations;
+}
+
+// CLI parsing
+const args = process.argv.slice(2);
+const options = {
+  format: 'text',
+  output: null,
+  fix: false
+};
+
+for (const arg of args) {
+  if (arg.startsWith('--format=')) {
+    options.format = arg.split('=')[1];
+  } else if (arg.startsWith('--output=')) {
+    options.output = arg.split('=')[1];
+  } else if (arg === '--fix') {
+    options.fix = true;
+  } else if (arg === '--help') {
+    console.log(`
+Hardcoded Scanner CLI
+
+Usage: node hardcoded-scanner.js [options]
+
+Options:
+  --format=json|text    Output format (default: text)
+  --output=path         Save report to file
+  --fix                 Attempt to fix violations (not implemented)
+  --help                Show this help message
+
+Exit codes:
+  0 - No violations or only warnings
+  1 - Critical or error violations found
+  2 - Scan execution failed
+`);
+    process.exit(0);
+  }
+}
+
+try {
+  scan(options);
+} catch (error) {
+  console.error('❌ Scan failed:', error.message);
+  process.exit(2);
+}


### PR DESCRIPTION
## 完成內容

### 1. 建立 ENVIRONMENT.md
- 定義端口配置標準 (PORT, VITE_PORT, TEST_PORT)
- 列出必要/可選環境變數
- 定義 URL 配置規則
- 建立掃描規則清單

### 2. 建立 hardcoded-scanner.js
- 自動化 CLI 工具，掃描 Codebase 中的硬編碼違規
- 支援規則：
  - Port 硬編碼 (3000, 3001, 3002, 8080, 5173)
  - URL 硬編碼 (外部 URL)
  - API Key/Token 硬編碼
  - 直接環境變數存取
- 輸出格式：text / JSON
- 可整合到 CI/CD

### 3. 掃描結果
發現 7 處違規：
- : 5 處 (端口 3001, 3000, GitHub API URL)
- : 1 處 (w3.org URL)
- : 1 處 (端口 3000)

## 驗收標準 ✅
- [x] 定義硬編碼規則清單（端口、環境變數、URL 等）
- [x] 開發 CLI 工具或 Script 執行掃描
- [x] 輸出掃描結果（檔案路徑 + 行號 + 違規內容）
- [x] 可整合到 CI/CD 流程

## 使用方式
```bash
# 運行掃描
node scripts/hardcoded-scanner.js

# JSON 輸出
node scripts/hardcoded-scanner.js --format=json --output=reports/scan.json
```

## Labels
devops